### PR TITLE
Included pretokenized setting in get_true_case() and added import Trainer functionality 

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -5,7 +5,7 @@ from truecase import Trainer
 
 class TestTrainer(unittest.TestCase):
     def setUp(self):
-        self.tc = Trainer.Trainer()
+        self.tc = Trainer()
 
     def test_get_casing(self):
         word = ""

--- a/truecase/TrueCaser.py
+++ b/truecase/TrueCaser.py
@@ -90,21 +90,34 @@ class TrueCaser(object):
     def first_token_case(self, raw):
         return f'{raw[0].upper()}{raw[1:]}'
 
-    def get_true_case(self, sentence, pretok=False, out_of_vocabulary_token_option="title"):
-        """ Returns the true case for the passed tokens.
-    
-        @param tokens: Tokens in a single sentence
-        @param pretokenised: set to true if input is alreay tokenised (e.g. string with whitespace between tokens)
-        @param outOfVocabulariyTokenOption:
+    def get_true_case(self, sentence, out_of_vocabulary_token_option="title"):
+        """ Wrapper function for handling untokenized input.
+        
+        @param sentence: a sentence string to be tokenized
+        @param outOfVocabularyTokenOption:
             title: Returns out of vocabulary (OOV) tokens in 'title' format
             lower: Returns OOV tokens in lower case
             as-is: Returns OOV tokens as is
+    
+        Returns (str): detokenized, truecased version of input sentence 
         """
-        if pretok:
-            tokens = sentence.split()
-        else:
-            tokens = self.tknzr.tokenize(sentence)
-
+        tokens = self.tknzr.tokenize(sentence)
+        tokens_true_case = self.get_true_case_from_tokens(tokens, out_of_vocabulary_token_option)
+        return "".join([" " + i if not i.startswith("'") and i not in string.punctuation else i for i in tokens_true_case]).strip()
+        
+    def get_true_case_from_tokens(self, tokens, out_of_vocabulary_token_option="title"):
+        """ Returns the true case for the passed tokens.
+    
+        @param tokens: List of tokens in a single sentence
+        @param pretokenised: set to true if input is alreay tokenised (e.g. string with whitespace between tokens)
+        @param outOfVocabularyTokenOption:
+            title: Returns out of vocabulary (OOV) tokens in 'title' format
+            lower: Returns OOV tokens in lower case
+            as-is: Returns OOV tokens as is
+        
+        Returns (list[str]): truecased version of input list
+        of tokens 
+        """
         tokens_true_case = []
         for token_idx, token in enumerate(tokens):
 
@@ -145,13 +158,8 @@ class TrueCaser(object):
                         tokens_true_case.append(token.lower())
                     else:
                         tokens_true_case.append(token)
-
-        if pretok:
-            result = ' '.join(tokens_true_case).strip()
-        else:
-            result = "".join([" " + i if not i.startswith("'") and i not in string.punctuation else i for i in tokens_true_case]).strip()
-
-        return result
+        
+        return tokens_true_case
 
 
 if __name__ == "__main__":

--- a/truecase/TrueCaser.py
+++ b/truecase/TrueCaser.py
@@ -90,7 +90,7 @@ class TrueCaser(object):
     def first_token_case(self, raw):
         return f'{raw[0].upper()}{raw[1:]}'
 
-    def get_true_case(self, sentence, pretokenised=False, out_of_vocabulary_token_option="title"):
+    def get_true_case(self, sentence, pretok=False, out_of_vocabulary_token_option="title"):
         """ Returns the true case for the passed tokens.
     
         @param tokens: Tokens in a single sentence
@@ -100,8 +100,8 @@ class TrueCaser(object):
             lower: Returns OOV tokens in lower case
             as-is: Returns OOV tokens as is
         """
-        if pretokenised:
-           tokens = sentence.split()
+        if pretok:
+            tokens = sentence.split()
         else:
             tokens = self.tknzr.tokenize(sentence)
 
@@ -146,7 +146,7 @@ class TrueCaser(object):
                     else:
                         tokens_true_case.append(token)
 
-        if pretokenised:
+        if pretok:
             result = ' '.join(tokens_true_case).strip()
         else:
             result = "".join([" " + i if not i.startswith("'") and i not in string.punctuation else i for i in tokens_true_case]).strip()

--- a/truecase/TrueCaser.py
+++ b/truecase/TrueCaser.py
@@ -90,16 +90,20 @@ class TrueCaser(object):
     def first_token_case(self, raw):
         return f'{raw[0].upper()}{raw[1:]}'
 
-    def get_true_case(self, sentence, out_of_vocabulary_token_option="title"):
+    def get_true_case(self, sentence, pretokenised=False, out_of_vocabulary_token_option="title"):
         """ Returns the true case for the passed tokens.
-
+    
         @param tokens: Tokens in a single sentence
+        @param pretokenised: set to true if input is alreay tokenised (e.g. string with whitespace between tokens)
         @param outOfVocabulariyTokenOption:
             title: Returns out of vocabulary (OOV) tokens in 'title' format
             lower: Returns OOV tokens in lower case
             as-is: Returns OOV tokens as is
         """
-        tokens = self.tknzr.tokenize(sentence)
+        if pretokenised:
+           tokens = sentence.split()
+        else:
+            tokens = self.tknzr.tokenize(sentence)
 
         tokens_true_case = []
         for token_idx, token in enumerate(tokens):
@@ -142,11 +146,12 @@ class TrueCaser(object):
                     else:
                         tokens_true_case.append(token)
 
-        return "".join([
-            " " +
-            i if not i.startswith("'") and i not in string.punctuation else i
-            for i in tokens_true_case
-        ]).strip()
+        if pretokenised:
+            result = ' '.join(tokens_true_case).strip()
+        else:
+            result = "".join([" " + i if not i.startswith("'") and i not in string.punctuation else i for i in tokens_true_case]).strip()
+
+        return result
 
 
 if __name__ == "__main__":

--- a/truecase/__init__.py
+++ b/truecase/__init__.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 from .Trainer import Trainer
 from .TrueCaser import TrueCaser
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 
 
 @lru_cache(maxsize=1)

--- a/truecase/__init__.py
+++ b/truecase/__init__.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-
+from .Trainer import Trainer
 from .TrueCaser import TrueCaser
 
 __version__ = "0.0.12"


### PR DESCRIPTION
Added a `pretok` flag to indicate whether input text is already tokenised.
If `True`, we simply split the pretokenised string on whitespace.
This avoids destroying pretokenised input by applying nltk's tokeniser to it.