### PR TITLE
Lambda function for out_of_vocabulary_token_option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Simple usecase:
 You can also pass an `out_of_vocabulary_token_option`, which will be used if a word is not found in the model's vocabulary
 ```python
 >>> import truecase
->>> truecase.get_true_case('my favorite music genre is hip-hop.', "capitalize")
+>>> truecase.get_true_case('my favorite music genre is hip-hop.', "title")
 'My favorite music genre is Hip-Hop.'
 ```
 `out_of_vocabulary_token_option`:
-- "capitalize" < DEFAULT
-- "title"
+- "title" < DEFAULT
+- "capitalize"
 - "lower"
 - Or, pass if your own lambda function
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,26 @@ Simple usecase:
 ```python
 >>> import truecase
 >>> truecase.get_true_case('hey, what is the weather in new york?')
-'Hey, what is the weather in New York?''
+'Hey, what is the weather in New York?'
 ```
 
+You can also pass an `out_of_vocabulary_token_option`, which will be used if a word is not found in the model's vocabulary
+```python
+>>> import truecase
+>>> truecase.get_true_case('my favorite music genre is hip-hop.', "capitalize")
+'My favorite music genre is Hip-Hop.'
+```
+`out_of_vocabulary_token_option`:
+- "capitalize" < DEFAULT
+- "title"
+- "lower"
+- Or, pass if your own lambda function
+
+```python
+>>> import truecase
+>>> truecase.get_true_case('i work in the nsa.', lambda token: token.upper())
+'I work in the NSA.'
+```
 ## Training your own model
 
 TODO. For now refer to Trainer.py

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Simple usecase:
 'Hey, what is the weather in New York?'
 ```
 
-You can also pass an `out_of_vocabulary_token_option`, which will be used if a word is not found in the model's vocabulary
+You can also pass an `out_of_vocabulary_token_option`, which will be used if a word is not found in the model's vocabulary:
 ```python
 >>> import truecase
 >>> truecase.get_true_case('my favorite music genre is hip-hop.', "title")
@@ -46,8 +46,11 @@ You can also pass an `out_of_vocabulary_token_option`, which will be used if a w
 - "title" < DEFAULT
 - "capitalize"
 - "lower"
-- Or, pass if your own lambda function
+- Or, pass if your own lambda function (takes the token with original casing as a single parameter)
 
+*If an invalid option is passed, title is used*
+
+Lambda function example:
 ```python
 >>> import truecase
 >>> truecase.get_true_case('i work in the nsa.', lambda token: token.upper())

--- a/tests/test_truecase.py
+++ b/tests/test_truecase.py
@@ -47,3 +47,8 @@ class TestTrueCase(unittest.TestCase):
         expected = "Testing $bug"
         result = self.tc.get_true_case(sentence)
         assert result == expected
+
+        sentence = "i work in the nsa."
+        expected = "I work in the NSA."
+        result = self.tc.get_true_case(sentence, lambda token: token.upper())
+        assert result == expected

--- a/truecase/TrueCaser.py
+++ b/truecase/TrueCaser.py
@@ -92,18 +92,18 @@ class TrueCaser(object):
     def first_token_case(self, raw):
         return raw.capitalize()
 
-    def out_of_vocabulary_handler(self, token, out_of_vocabulary_token_option="title"):
+    def out_of_vocabulary_handler(self, token_og_case, out_of_vocabulary_token_option="title"):
         if isinstance(out_of_vocabulary_token_option, Callable):
-            return out_of_vocabulary_token_option(token)
+            return out_of_vocabulary_token_option(token_og_case)
         elif out_of_vocabulary_token_option == "title":
-            return token.title()
+            return token_og_case.title()
         elif out_of_vocabulary_token_option == "capitalize":
-            return token.capitalize()
+            return token_og_case.capitalize()
         elif out_of_vocabulary_token_option == "lower":
-            return token.lower()
+            return token_og_case.lower()
         else:
-            # Return original casing
-            return token
+            # If value passed is invalid, use .title()
+            return token_og_case.title()
 
     def get_true_case(self, sentence, out_of_vocabulary_token_option="title"):
         """ Wrapper function for handling untokenized input.

--- a/truecase/TrueCaser.py
+++ b/truecase/TrueCaser.py
@@ -91,6 +91,17 @@ class TrueCaser(object):
     def first_token_case(self, raw):
         return raw.capitalize()
 
+    def out_of_vocabulary_handler(self, token, out_of_vocabulary_token_option="title"):
+        if out_of_vocabulary_token_option == "title":
+            return token.title()
+        elif out_of_vocabulary_token_option == "capitalize":
+            return token.capitalize()
+        elif out_of_vocabulary_token_option == "lower":
+            return token.lower()
+        else:
+            # Return original casing
+            return token
+
     def get_true_case(self, sentence, out_of_vocabulary_token_option="title"):
         """ Wrapper function for handling untokenized input.
         
@@ -121,7 +132,7 @@ class TrueCaser(object):
         """
         tokens_true_case = []
         for token_idx, token in enumerate(tokens):
-
+            token_og_case = token
             if token in string.punctuation or token.isdigit():
                 tokens_true_case.append(token)
             else:
@@ -154,14 +165,7 @@ class TrueCaser(object):
                             tokens_true_case[0])
 
                 else:  # Token out of vocabulary
-                    if out_of_vocabulary_token_option == "title":
-                        tokens_true_case.append(token.title())
-                    elif out_of_vocabulary_token_option == "capitalize":
-                        tokens_true_case.append(token.capitalize())
-                    elif out_of_vocabulary_token_option == "lower":
-                        tokens_true_case.append(token.lower())
-                    else:
-                        tokens_true_case.append(token)
+                    tokens_true_case.append(self.out_of_vocabulary_handler(token_og_case, out_of_vocabulary_token_option))
 
         return tokens_true_case
 

--- a/truecase/TrueCaser.py
+++ b/truecase/TrueCaser.py
@@ -2,6 +2,7 @@ import math
 import os
 import pickle
 import string
+from typing import Callable
 
 import nltk
 from nltk.tokenize import word_tokenize
@@ -92,7 +93,9 @@ class TrueCaser(object):
         return raw.capitalize()
 
     def out_of_vocabulary_handler(self, token, out_of_vocabulary_token_option="title"):
-        if out_of_vocabulary_token_option == "title":
+        if isinstance(out_of_vocabulary_token_option, Callable):
+            return out_of_vocabulary_token_option(token)
+        elif out_of_vocabulary_token_option == "title":
             return token.title()
         elif out_of_vocabulary_token_option == "capitalize":
             return token.capitalize()


### PR DESCRIPTION
This is a solution for lambda function feature request in #23

1. Created `out_of_vocabulary_handler`
    - Added ability to handle lambda function
        - the lambda function gets token_og_case, which has the original casing
    - I realized that the current release is implicitly using `.lower()` if an invalid option for `out_of_vocabulary_token_option` is passed (eg: `out_of_vocabulary_token_option = 'upper'`)
        - This is due to [L128](https://github.com/daltonfury42/truecase/blob/master/truecase/TrueCaser.py#L128).
        - I'm now passing the token with original casing to the handler function. If an invalid option is passed, I will use `.title()`
2. Added test case for lambda function.
3. Updated README for out_of_vocab options